### PR TITLE
fortitude: Enable `nonportable-shortcircuit-inquiry` rule

### DIFF
--- a/fortitude.toml
+++ b/fortitude.toml
@@ -4,7 +4,6 @@ ignore = [
   "star-kind", # don't use integer*4 et al
   "literal-kind",
   "unchecked-stat",  # TODO: Fix this!
-  "nonportable-shortcircuit-inquiry",  # TODO: Fix this!
 ]
 line-length = 132
 show-fixes = true

--- a/src/modules/BundleIOModule.f90
+++ b/src/modules/BundleIOModule.f90
@@ -271,8 +271,10 @@ contains
 
       ! 2. work out if we are opening a new file
       file_exists = .true.
-      if (present(firsttime) .and. firsttime) then
-         inquire (file=file_name, exist=file_exists)
+      if (present(firsttime)) then
+         if (firsttime) then
+            inquire (file=file_name, exist=file_exists)
+         end if
       end if
 
       ! 3. open the file

--- a/src/modules/TrajectoryIOModule.f90
+++ b/src/modules/TrajectoryIOModule.f90
@@ -266,8 +266,10 @@ contains
       long_file_name = trim(FMSWorkingDir)//file_name
 
       file_existed = .true.
-      if (present(first_time) .and. first_time) then
-         inquire (file=long_file_name, exist=file_existed)
+      if (present(first_time)) then
+         if (first_time) then
+            inquire (file=long_file_name, exist=file_existed)
+         end if
       end if
 
       if (.not. file_existed) then
@@ -684,8 +686,10 @@ contains
       long_file_name = trim(FMSWorkingDir)//file_name
 
       file_existed = .true.
-      if (present(first_time) .and. first_time) then
-         inquire (file=long_file_name, exist=file_existed)
+      if (present(first_time)) then
+         if (first_time) then
+            inquire (file=long_file_name, exist=file_existed)
+         end if
       end if
 
       if (.not. file_existed) then
@@ -778,8 +782,10 @@ contains
       long_file_name = trim(FMSWorkingDir)//file_name
 
       file_existed = .true.
-      if (present(first_time) .and. first_time) then
-         inquire (file=long_file_name, exist=file_existed)
+      if (present(first_time)) then
+         if (first_time) then
+            inquire (file=long_file_name, exist=file_existed)
+         end if
       end if
 
       if (.not. file_existed) then
@@ -838,8 +844,10 @@ contains
       long_file_name = trim(FMSWorkingDir)//file_name
 
       file_existed = .true.
-      if (present(first_time) .and. first_time) then
-         inquire (file=long_file_name, exist=file_existed)
+      if (present(first_time)) then
+         if (first_time) then
+            inquire (file=long_file_name, exist=file_existed)
+         end if
       end if
 
 !     create column labels


### PR DESCRIPTION
Fortitude provides a nice explanation of the problem here:

```console
$ fortitude explain nonportable-shortcircuit-inquiry
C161: nonportable-shortcircuit-inquiry

What it does
Checks for use of a variable in the same logical expression as "definedness" inquiry.

Why is this bad?
Unlike many other languages, the Fortran standard doesn't mandate (or prohibit)
short-circuiting in logical expressions, so different compilers have different
behaviour when it comes to evaluating such expressions. This is commonly encountered
when using present() with an optional dummy argument and checking its value in the
same expression. Without short-circuiting, this can lead to segmentation faults when
the expression is evaluated if the argument isn't present.
...
```