### PR TITLE
fortitude: enable `unchecked-stat` rule

### DIFF
--- a/fortitude.toml
+++ b/fortitude.toml
@@ -3,7 +3,6 @@ ignore = [
   "implicit-external-procedures", # requires Fortran 2018
   "star-kind", # don't use integer*4 et al
   "literal-kind",
-  "unchecked-stat",  # TODO: Fix this!
 ]
 line-length = 132
 show-fixes = true

--- a/src/modules/RestartModule.f90
+++ b/src/modules/RestartModule.f90
@@ -700,51 +700,37 @@ contains
 3     format(10(1x, es15.8))
 
       write (nf, *) '# Orbitals'
-      write (nf, 3, iostat=ierr) ES%OldOrbitals
+      write (nf, 3) ES%OldOrbitals
       write (nf, *) '# CI vectors'
-      write (nf, 3, iostat=ierr) ES%OldCIVecs
+      write (nf, 3) ES%OldCIVecs
       write (nf, *) '# Overlap matrix'
-      write (nf, 3, iostat=ierr) ES%OverlapMatrix
+      write (nf, 3) ES%OverlapMatrix
       write (nf, *) '# TC Blob'
-      write (nf, 3, iostat=ierr) ES%OldBlob
+      write (nf, 3) ES%OldBlob
       write (nf, *) '# MSPT2 Coeffs'
-      write (nf, 3, iostat=ierr) ES%OldMSPT2C
+      write (nf, 3) ES%OldMSPT2C
       write (nf, *) '# Electronic Phases'
-      write (nf, *, iostat=ierr) ES%ElecPhase
-
-      return
+      write (nf, *) ES%ElecPhase
    end subroutine WriteElecStruc
 
-! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   subroutine ReadElecStruc(ES, nfile_in)
-! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   subroutine ReadElecStruc(ES, nf)
       type(T_ElecStruc), intent(inout) :: ES
-      integer(kind=DefInt), optional :: nfile_in
-
-      integer(kind=DefInt) :: nf ! unit number to write to
-! WTF: We shouldn't just blidly ignore all errors!
-      integer(kind=DefInt) :: ierr ! catch errors that may be thrown
-
-! set which file we are writing to
-      nf = 5
-      if (present(nfile_in)) nf = nfile_in
+      integer(kind=DefInt), intent(in) :: nf
 
 3     format(10(1x, es15.8))
 
       read (nf, *)
-      read (nf, 3, iostat=ierr) ES%OldOrbitals
+      read (nf, 3) ES%OldOrbitals
       read (nf, *)
-      read (nf, 3, iostat=ierr) ES%OldCIVecs
+      read (nf, 3) ES%OldCIVecs
       read (nf, *)
-      read (nf, 3, iostat=ierr) ES%OverlapMatrix
+      read (nf, 3) ES%OverlapMatrix
       read (nf, *)
-      read (nf, 3, iostat=ierr) ES%OldBlob
+      read (nf, 3) ES%OldBlob
       read (nf, *)
-      read (nf, 3, iostat=ierr) ES%OldMSPT2C
+      read (nf, 3) ES%OldMSPT2C
       read (nf, *)
-!DEBUG - changed v from read(nf,3,iostat=ierr)
-      read (nf, *, iostat=ierr) ES%ElecPhase
-      return
+      read (nf, *) ES%ElecPhase
    end subroutine ReadElecStruc
 
 ! * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/src/modules/SamplingModule.f90
+++ b/src/modules/SamplingModule.f90
@@ -1082,7 +1082,7 @@ contains
 
       case ('HESS')
          filein = trim(FMSWorkingDir)//'Hessian.dat'
-         open (newunit=ifunit, file=filein, status='old', action='read', iostat=ios)
+         open (newunit=ifunit, file=filein, status='old', action='read')
          write (fmiOut, *) 'Using Hessian.dat to find normal mode frequencies'
          read (IFUnit, *, end=999) natomsin
          if (natomsin /= natoms) then


### PR DESCRIPTION
Ignoring IO errors is **BAD**!

```console
$ fortitude explain unchecked-stat
C181: unchecked-stat

What does it do?
This rule detects whether a stat, iostat, and cmdstat argument is checked
within the same scope it is set.

Why is this bad?
By default, allocate statements will abort the program if the allocation
fails. This is often the desired behaviour, but to provide for cases in
which the developer wants to handle allocation errors gracefully, they may
optionally check the status of an allocate statement by passing a variable
to the stat argument:

allocate (x(BIG_INT), stat=status)
if (status /= 0) then             
  call handle_error(status)       
end if                            

However, if the stat variable is not checked, the program will continue to
run despite the allocation failure, which can lead to undefined behaviour.
Similar behaviour is exhibited by deallocate and IO statements such as
open, read, and close.

To avoid confusing and bug-prone control flow, the checks on status parameters
should occur within the same scope in which they are set.
```