### PR TITLE
fortitude: Autofixes from preview rules

### DIFF
--- a/src/modules/ElecStrucModule.f90
+++ b/src/modules/ElecStrucModule.f90
@@ -16,7 +16,6 @@
 module ElecStrucModule
    use GlobalModule, only: DefReal, DefInt, fmiOut
    implicit none
-   save
    public
 
 !     What can this electronic structure method do?

--- a/src/modules/GlobalModule.f90
+++ b/src/modules/GlobalModule.f90
@@ -10,7 +10,6 @@
 module GlobalModule
    implicit none
    public
-   save
 
 !---------------------------------------------------------------------------
 !                       COMPILE-TIME CONSTANTS
@@ -397,7 +396,7 @@ contains
 !!    \param SetVal   Logical to flag step as rejected or not
 !<
    subroutine FMS_RejectStep(SetVal)
-      logical, intent(IN) :: SetVal
+      logical, intent(in) :: SetVal
 
       if (.not. SetVal) then
          glzRejectStep = SetVal

--- a/src/modules/InitialModule.f90
+++ b/src/modules/InitialModule.f90
@@ -6,7 +6,6 @@ module InitialModule
    use GlobalModule, only: DefInt, DefReal, DefInt4, fmiOut
    implicit none
    public
-   save
 
 !> Initial state to create wavefunctions on
    integer(kind=DefInt) :: inInitState

--- a/src/modules/MinSearchModule.f90
+++ b/src/modules/MinSearchModule.f90
@@ -16,7 +16,6 @@ module MinSearchModule
    implicit none
    private
    public :: FMS_Minimizer
-   save
 
    ! enumerate tyoe for the minimization
    integer(DefInt), public :: mnMinType

--- a/src/modules/QM_MM_Module.f90
+++ b/src/modules/QM_MM_Module.f90
@@ -8,7 +8,6 @@ module QM_MM_Module
    implicit none
    public
    private :: defInt, defReal, MaxParticles
-   save
 
    logical :: qcZQMMM = .false. !< Is this a QM/MM simulation?
    integer(kind=DefInt) :: qcNumMM = 0 !< Number of MM atoms

--- a/src/modules/RattleModule.f90
+++ b/src/modules/RattleModule.f90
@@ -15,7 +15,6 @@ module RattleModule
              Rattle_Constrain_Momentum
    public :: constraint, D_constraint, all_position_constrained
 
-   save
    logical :: constraints_set = .false.
 
    integer(kind=DefInt), public :: nconstraint ! Number of constraints

--- a/src/modules/SMDModule.f90
+++ b/src/modules/SMDModule.f90
@@ -8,7 +8,6 @@ module SMDModule
    use GlobalModule, only: DefReal, DefInt, FMS_DieError
    use TrajectoryModule
    implicit none
-   save
 
    private
    public :: SMD_Mechano, SMD_Print, SMD_Completed

--- a/src/modules/SamplingModule.f90
+++ b/src/modules/SamplingModule.f90
@@ -43,7 +43,6 @@ module SamplingModule
 !> For quasiclassical initial conditions, modes with extra quanta
    integer(kind=DefInt), public :: inIAddQuanta(100)
 
-   save
 contains
 
 !>

--- a/src/modules/TemplateModule.f90
+++ b/src/modules/TemplateModule.f90
@@ -11,7 +11,6 @@
 module TemplateModule
    use GlobalModule
    implicit none
-   save
    private
    public :: FMS_TemplateInit, FMS_TemplateClean
    public :: FMS_RunCommand, FMS_WriteInput, FMS_ReadOutput

--- a/src/modules/ThermoModule.f90
+++ b/src/modules/ThermoModule.f90
@@ -4,10 +4,10 @@ module ThermoModule
    implicit none
    private
    public :: thermo_init, thermo, thermo_bussi_global, thermo_bussi_local, thermo_NormDist, thermo_MBDist
-   character(len=8), save :: therm = '' !which thermostat to use in simple interface
-   double precision, save :: beta_s = 0.0 !inverse temperature in simple interface
-   double precision, save :: thermtime = 0.0 !Thermostat relaxation time (in au) for simple interface
-   logical, save :: zcom_s = .true. !Do center of mass removal in simple interface?
+   character(len=8) :: therm = '' !which thermostat to use in simple interface
+   double precision :: beta_s = 0.0 !inverse temperature in simple interface
+   double precision :: thermtime = 0.0 !Thermostat relaxation time (in au) for simple interface
+   logical :: zcom_s = .true. !Do center of mass removal in simple interface?
    integer(4), parameter :: i4one = 1 !Ensure type is consistent with uses of integer(4)
 
 contains

--- a/src/modules/ToyModelModule.f90
+++ b/src/modules/ToyModelModule.f90
@@ -421,8 +421,8 @@ contains
 !! Returns Tully 1 diabatic Hamiltonian
 !<
       subroutine Tully(x, sigma)
-         real(kind=DefReal), intent(IN) :: x
-         real(kind=DefReal), intent(OUT) :: sigma
+         real(kind=DefReal), intent(in) :: x
+         real(kind=DefReal), intent(out) :: sigma
          real(kind=DefReal) :: rsigma, drsigma
 
          rsigma = 8.0d0
@@ -453,8 +453,8 @@ contains
 !! Returns Persico diabatic Hamiltonian
 !<
       subroutine Persico(x, y, H)
-         real(kind=DefReal), intent(IN) :: x, y
-         real(kind=DefReal), intent(OUT) :: H(2, 2)
+         real(kind=DefReal), intent(in) :: x, y
+         real(kind=DefReal), intent(out) :: H(2, 2)
          H(1, 1) = 0.5d0 * KX * (x - X1)**2 + 0.5d0 * KY * y * y
          H(2, 2) = 0.5d0 * KX * (x - X2)**2 + 0.5d0 * KY * y * y + Delta
          H(1, 2) = gamma * y * exp(-alpha * (x - X3)**2) * exp(-beta * y * y)
@@ -466,8 +466,8 @@ contains
 !<
 
       subroutine Izmaylov(x, y, H)
-         real(kind=DefReal), intent(IN) :: x, y
-         real(kind=DefReal), intent(OUT) :: H(2, 2)
+         real(kind=DefReal), intent(in) :: x, y
+         real(kind=DefReal), intent(out) :: H(2, 2)
          H(1, 1) = 0.5d0 * (W1**2) * (x + 0.5d0 * XA)**2 + 0.5d0 * (W2**2) * &
                    (y + 0.5d0 * YA)**2 + 0.5d0 * deltaE
          H(2, 2) = 0.5d0 * (W1**2) * (x - 0.5d0 * XA)**2 + 0.5d0 * (W2**2) * &
@@ -481,8 +481,8 @@ contains
 !<
 
       subroutine GAIMS_md(x, H)
-         real(kind=DefReal), intent(IN) :: x
-         real(kind=DefReal), intent(OUT) :: H(2, 2)
+         real(kind=DefReal), intent(in) :: x
+         real(kind=DefReal), intent(out) :: H(2, 2)
 
          ! Step function sigma(r) controlling SOC sign change, Eq (21)
          if (x <= r_sigma - dr_sigma / 2) then
@@ -517,8 +517,8 @@ contains
 !! This is done analytically, since we can.
 !<
       subroutine diagABBC(H, EVec1, EVec2)
-         real(kind=DefReal), intent(IN) :: H(2, 2)
-         real(kind=DefReal), intent(OUT) :: EVec1(2), EVec2(2)
+         real(kind=DefReal), intent(in) :: H(2, 2)
+         real(kind=DefReal), intent(out) :: EVec1(2), EVec2(2)
          real(kind=DefReal) :: A, B, C, norm
 
          if (H(2, 1) /= H(1, 2)) call FMS_DieError( &

--- a/src/modules/TrajectoryCalcsModule.f90
+++ b/src/modules/TrajectoryCalcsModule.f90
@@ -1693,7 +1693,7 @@ contains
 
 !     Bundle scope routines
    function FMS_IsBundleCurrent(T1) result(zCurrent)
-      type(T_Trajectory), intent(IN) :: T1
+      type(T_Trajectory), intent(in) :: T1
       logical :: zCurrent
 
       zCurrent = T1%BFlags%zBundleCurrent
@@ -1708,7 +1708,7 @@ contains
    end subroutine FMS_BundleUpdated
 
    function FMS_IsAmpDotCurrent(T1) result(zCurrent)
-      type(T_Trajectory), intent(IN) :: T1
+      type(T_Trajectory), intent(in) :: T1
       logical :: zCurrent
 
       zCurrent = T1%BFlags%zAmpDotCurrent


### PR DESCRIPTION
Couple more autofixes from fortitude:
 - superfluous `save` statements
 - lower-case "in/out/inout" 

```console
❯ fortitude explain MOD051
MOD051: superfluous-save

# What it does
Checks for unnecessary save statements and qualifiers

# Why is this bad?
Since Fortran 2008, module variables are implicitly saved. Save statements
and attributes can safely be removed.

# Example
module example        
    integer, save :: a
end module example    
or
module example    
    save          
                  
    integer :: a  
end module example

Use instead:
module example    
    integer :: a  
end module example
```


```console
❯ fortitude explain S233
S233: incorrect-keyword-case

# What it does
Checks that Fortran keywords use a consistent casing style. Flags any keyword
whose casing does not match the configured style (see
[keyword-case](https://fortitude.readthedocs.io/en/stable/settings#keyword-case)).

# Why is this bad?
Fortran is case-insensitive, so keyword casing is purely a stylistic choice.
However, inconsistent casing — mixing IMPLICIT NONE, implicit none, and
Implicit None in the same codebase — reduces readability and makes code
harder to scan. Enforcing a consistent style helps maintain a uniform
appearance across the codebase.

Modern Fortran style guides generally favour lowercase keywords. Older
codebases often use uppercase, inherited from fixed-form Fortran conventions.
```