### PR TITLE
Flush selected output files

### DIFF
--- a/src/dynamics.f90
+++ b/src/dynamics.f90
@@ -64,6 +64,7 @@
             else
                write (fmiOut, 2131) Bundle%CurrentTime, TimeStep, Bundle%NumTraj
             end if
+            flush (fmiOut)
 
 !     Propagate bundle through 1 timestep
             call PropagateBundle(Bundle, Timestep)
@@ -129,6 +130,7 @@
             ! save Bundle
             call PutRestart(Bundle)
             call FMS_CheckStop(Bundle)
+            flush (fmiOut)
 
             ! end of MD loop
          end do

--- a/src/modules/BundleIOModule.f90
+++ b/src/modules/BundleIOModule.f90
@@ -57,6 +57,7 @@ contains
       call FMS_Branching(B1, Prob)
 
       write (IUnit, '(1x,f11.2,50(1x,f11.9))') B1%CurrentTime, (Prob(i), i=1, nstate), FMS_Norm(B1)
+      flush (IUnit)
 
    end subroutine FMS_WriteFBranching
 

--- a/src/modules/TrajectoryIOModule.f90
+++ b/src/modules/TrajectoryIOModule.f90
@@ -235,6 +235,7 @@ contains
       end if
 
       write (iunit, '(f10.2,4(f10.4))') T%get_time(), FMS_Weight(T), T%Amplitude
+      flush (iunit)
 
    end subroutine FMS_WriteFAmp
 !>


### PR DESCRIPTION
Added flushing of specific files, as suggested in #40. Flushing was already present for `positions` so this is only for timesteps, `N.dat`, and `Amp.*`