### PR TITLE
First numerical unit test for the overlap module

### DIFF
--- a/cmake/OpenFMSUnitTests.cmake
+++ b/cmake/OpenFMSUnitTests.cmake
@@ -4,6 +4,7 @@ function(openfms_add_unit_tests openfms_core_target)
     unit_tests/test_bundle.F90
     unit_tests/test_particle.F90
     unit_tests/test_trajectory.F90
+    unit_tests/test_overlap.F90
     unit_tests/testdrive.F90
     unit_tests/testutils.F90
   )

--- a/src/modules/ElecStrucModule.f90
+++ b/src/modules/ElecStrucModule.f90
@@ -97,12 +97,13 @@ contains
 !!    \param NumStates Number of electronic states
 !!    @ingroup ESP
 !<
-   subroutine FMS_ESInit(NumParticles, NumStates)
+   subroutine FMS_ESInit(NumParticles, NumStates, suppress_write)
       use GlobalModule, only: gliModel, gliMethod, &
                               FMSZERO, QUANTICS, TC, TEMPLATE, FMS_DieError
 
       integer(kind=DefInt), intent(in) :: NumParticles
       integer(kind=DefInt), intent(inout) :: NumStates
+      logical, intent(in), optional :: suppress_write
 
 !
 !     Set defaults
@@ -126,7 +127,9 @@ contains
 !     FMSZero: fake electronic structure
 !
       case (FMSZERO)
-         write (fmiOut, *) 'FMSZero: Using toy potentials in adiabatic basis.'
+         if (present(suppress_write) .eqv. .false.) then
+            write (fmiOut, *) 'FMSZero: Using toy potentials in adiabatic basis.'
+         end if
          eszAnalyticForces = .true.
          eszNACoupVec = .true.
          eszPartialCharges = .false.
@@ -152,9 +155,13 @@ contains
             end if
 
          case (3)
-            write (fmiOut, *) 'gliMethod=3: Izmaylov Model 2D 2-state CI'
+            if (present(suppress_write) .eqv. .false.) then
+               write (fmiOut, *) 'gliMethod=3: Izmaylov Model 2D 2-state CI'
+            end if
             if (NumStates /= 2) then
-               write (fmiOut, *) 'Number of states set to 2.'
+               if (present(suppress_write) .eqv. .false.) then
+                  write (fmiOut, *) 'Number of states set to 2.'
+               end if
                NumStates = 2
             end if
             if (NumParticles < 2) then

--- a/src/modules/ElecStrucModule.f90
+++ b/src/modules/ElecStrucModule.f90
@@ -97,13 +97,12 @@ contains
 !!    \param NumStates Number of electronic states
 !!    @ingroup ESP
 !<
-   subroutine FMS_ESInit(NumParticles, NumStates, suppress_write)
+   subroutine FMS_ESInit(NumParticles, NumStates)
       use GlobalModule, only: gliModel, gliMethod, &
                               FMSZERO, QUANTICS, TC, TEMPLATE, FMS_DieError
 
       integer(kind=DefInt), intent(in) :: NumParticles
       integer(kind=DefInt), intent(inout) :: NumStates
-      logical, intent(in), optional :: suppress_write
 
 !
 !     Set defaults
@@ -127,9 +126,7 @@ contains
 !     FMSZero: fake electronic structure
 !
       case (FMSZERO)
-         if (present(suppress_write) .eqv. .false.) then
-            write (fmiOut, *) 'FMSZero: Using toy potentials in adiabatic basis.'
-         end if
+         write (fmiOut, *) 'FMSZero: Using toy potentials in adiabatic basis.'
          eszAnalyticForces = .true.
          eszNACoupVec = .true.
          eszPartialCharges = .false.
@@ -155,13 +152,9 @@ contains
             end if
 
          case (3)
-            if (present(suppress_write) .eqv. .false.) then
-               write (fmiOut, *) 'gliMethod=3: Izmaylov Model 2D 2-state CI'
-            end if
+            write (fmiOut, *) 'gliMethod=3: Izmaylov Model 2D 2-state CI'
             if (NumStates /= 2) then
-               if (present(suppress_write) .eqv. .false.) then
-                  write (fmiOut, *) 'Number of states set to 2.'
-               end if
+               write (fmiOut, *) 'Number of states set to 2.'
                NumStates = 2
             end if
             if (NumParticles < 2) then

--- a/src/modules/OverlapModule.f90
+++ b/src/modules/OverlapModule.f90
@@ -910,6 +910,22 @@ contains
          S_ij = overlap_trajectory(T1, T2)
       end if
 
+!  The necessity of the minus sign in the first term can be seen by looking
+!  at the i-th TBF
+!
+!  χ_i = N exp(-α * (R - R_i)**2 + i P_i (R-R_i) + i ɣ_i)
+!
+!  Then taking the gradient of chi_i with respect to the nuclear configuration
+!  space variable R (not the parameter!) we get
+!
+!  ∇_R χ_i = [ α (R - R_i) + i P_i ] χ_i
+!
+! while if we take the gradient with respect to the parameter
+! R_i (the center of the Gaussian) we get
+!
+!  ∇_{R_i} χ_i = [- α (R - R_i) - i P_i ] χ_i
+!
+!  Thus it follows that ∇_R χ_i = - ∇_{R_i} χ_i
       S_dot = (-dot_product(T2%get_vel(), &
                             overlap_dx_trajectory(T1, T2, S_ij)) &
                + dot_product(FMS_Forces(T2), &

--- a/src/modules/OverlapModule.f90
+++ b/src/modules/OverlapModule.f90
@@ -910,22 +910,22 @@ contains
          S_ij = overlap_trajectory(T1, T2)
       end if
 
-!  The necessity of the minus sign in the first term can be seen by looking
-!  at the i-th TBF
-!
-!  χ_i = N exp(-α * (R - R_i)**2 + i P_i (R-R_i) + i ɣ_i)
-!
-!  Then taking the gradient of chi_i with respect to the nuclear configuration
-!  space variable R (not the parameter!) we get
-!
-!  ∇_R χ_i = [ α (R - R_i) + i P_i ] χ_i
-!
-! while if we take the gradient with respect to the parameter
-! R_i (the center of the Gaussian) we get
-!
-!  ∇_{R_i} χ_i = [- α (R - R_i) - i P_i ] χ_i
-!
-!  Thus it follows that ∇_R χ_i = - ∇_{R_i} χ_i
+      !  The necessity of the minus sign in the first term can be seen by looking
+      !  at the i-th TBF
+      !
+      !  χ_i = N exp(-α * (R - R_i)**2 + i P_i (R-R_i) + i ɣ_i)
+      !
+      !  Then taking the gradient of chi_i with respect to the nuclear configuration
+      !  space variable R (not the parameter!) we get
+      !
+      !  ∇_R χ_i = [ α (R - R_i) + i P_i ] χ_i
+      !
+      ! while if we take the gradient with respect to the parameter
+      ! R_i (the center of the Gaussian) we get
+      !
+      !  ∇_{R_i} χ_i = [- α (R - R_i) - i P_i ] χ_i
+      !
+      !  Thus it follows that ∇_R χ_i = - ∇_{R_i} χ_i
       S_dot = (-dot_product(T2%get_vel(), &
                             overlap_dx_trajectory(T1, T2, S_ij)) &
                + dot_product(FMS_Forces(T2), &

--- a/src/modules/OverlapModule.f90
+++ b/src/modules/OverlapModule.f90
@@ -910,19 +910,6 @@ contains
          S_ij = overlap_trajectory(T1, T2)
       end if
 
-! I don't understand the need for the minus
-! but it is important, the norm is not conserved otherwise
-!
-! TODO(danielhollas): On HDF_free branch, there's this additional comment,
-! but there's no minus sign anymore! We should make sure the formula below is correct.
-!
-! Tuesday, 20 December 2011 12:01:21
-!  Worked out the problem:
-!     overlap_dx   = < g1 | d/dx | g2 >
-! This equation actually needs
-!     overlap_dx_2 = < g1 | d/dx_2 | g2 >
-! A little algebra shows
-!     overlap_dx  = -overlap_dx_2
       S_dot = (-dot_product(T2%get_vel(), &
                             overlap_dx_trajectory(T1, T2, S_ij)) &
                + dot_product(FMS_Forces(T2), &

--- a/unit_tests/main.F90
+++ b/unit_tests/main.F90
@@ -6,6 +6,7 @@ program tester
    use test_particle, only: collect_particle_suite
    use test_trajectory, only: collect_trajectory_suite
    use test_bundle, only: collect_bundle_suite
+   use test_overlap, only: collect_overlap_suite
    use GlobalModule, only: set_error_handler
    implicit none
    integer :: num_failed_tests, is, num_args, selected_suite_index
@@ -39,7 +40,8 @@ program tester
    testsuites = [ &
                 new_testsuite('ParticleModule', collect_particle_suite), &
                 new_testsuite('TrajectoryModule', collect_trajectory_suite), &
-                new_testsuite('BundleModule', collect_bundle_suite) &
+                new_testsuite('BundleModule', collect_bundle_suite), &
+                new_testsuite('OverlapModule', collect_overlap_suite) &
                 ]
 
    ! Swap the default FMS_DieError handler for a unit-test friendly

--- a/unit_tests/test_overlap.F90
+++ b/unit_tests/test_overlap.F90
@@ -1,7 +1,7 @@
 module test_overlap
    use testdrive, only: new_unittest, unittest_type, error_type, check
    use testutils, only: check_dieerror_called
-   use GlobalModule, only: DefReal, DefInt
+   use GlobalModule, only: DefReal, DefInt, fmiOut
    use OverlapModule, only: overlap, overlap_S_dot
    use TrajectoryModule
    implicit none
@@ -86,7 +86,8 @@ contains
       glIzmYshift = 0.0
       glIzmDeltaE = 0.01984
       glIzmCoupC = 0.0006127
-      call FMS_ESInit(num_particles, num_states, suppress_write=.true.)
+      fmiOut = open_fms_out_to_null()
+      call FMS_ESInit(num_particles, num_states)
       call T1%create(numparticles=num_particles, numstates=num_states)
       call T2%create(numparticles=num_particles, numstates=num_states)
 
@@ -130,5 +131,12 @@ contains
       call T1%destroy()
       call T2%destroy()
    end subroutine test_overlap_S_dot
+
+   function open_fms_out_to_null() result(output_unit)
+      integer :: output_unit
+      character(len=256) :: filepath
+
+      open (newunit=output_unit, file='/dev/null', status='replace')
+   end function open_fms_out_to_null
 
 end module test_overlap

--- a/unit_tests/test_overlap.F90
+++ b/unit_tests/test_overlap.F90
@@ -1,0 +1,132 @@
+module test_overlap
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use testutils, only: check_dieerror_called
+   use GlobalModule, only: DefReal, DefInt
+   use OverlapModule, only: overlap, overlap_S_dot
+   use TrajectoryModule
+   implicit none
+   private
+
+   public :: collect_overlap_suite
+   real(kind=DefReal), parameter :: atol = 1.d-10
+   real(kind=DefReal), parameter :: rtol = 1.d-9
+
+contains
+
+!> Collect all exported unit tests
+   subroutine collect_overlap_suite(testsuite)
+      !> Collection of tests
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest('overlap_S_dot', test_overlap_S_dot) &
+                  ]
+
+   end subroutine collect_overlap_suite
+
+   function get_numerical_time_derivative(T1, T2, integral_type) result(num_dt)
+      use VerletModule, only: FMS_PropVV
+      type(T_Trajectory), intent(in) :: T1, T2
+      character, intent(in) :: integral_type
+      type(T_Trajectory) :: T1_tmp, T2_tmp
+      complex(kind=DefReal) :: num_dt(7)
+      real(kind=DefReal) :: step_size
+      complex(kind=DefReal) :: tmp_num_deriv, tmp
+      integer(kind=DefInt) :: i_direction, j_step, nr_steps, k, l
+
+      step_size = 1.d-1
+      num_dt = 0.d0
+      nr_steps = 7
+      do j_step = 1, nr_steps
+         tmp_num_deriv = 0.d0
+
+         do k = 1, 2
+            T1_tmp = T1
+            T2_tmp = T2
+
+            !call FMS_PropVV(T1_tmp, (-1.d0)**k * step_size)
+            call FMS_PropVV(T2_tmp, (-1.d0)**k * step_size)
+
+            select case (integral_type)
+            case ('S')
+               tmp = overlap(T1_tmp, T2_tmp)
+            case default
+               return
+            end select
+            tmp_num_deriv = tmp_num_deriv + (-1)**k * tmp
+         end do
+
+         num_dt = 0.5d0 * tmp_num_deriv / step_size
+         step_size = step_size * 1.d-1
+      end do
+   end function get_numerical_time_derivative
+
+   subroutine test_overlap_S_dot(error)
+      use GlobalModule, only: gliModel, gliMethod, glIzmOmegax, glIzmOmegay, &
+                              glIzmXshift, glIzmYshift, glIzmDeltaE, glIzmCoupC
+      use TrajectoryCalcsModule, only: FMS_Forces
+      use ElecStrucModule
+      type(error_type), allocatable, intent(out) :: error
+      type(t_trajectory) :: T1, T2
+      integer(kind=DefInt) :: num_particles, num_states
+      complex(kind=DefReal) :: SDot_analytical(7)
+      complex(kind=DefReal) :: SDot_numerical(7)
+      real(kind=DefReal) :: pos(6), mom(6), vel(6), force(6)
+      real(kind=DefReal) :: mass
+      real(kind=DefReal) :: min_err
+
+      num_particles = 2
+      num_states = 1
+      gliModel = 0
+      gliMethod = 3
+      glIzmOmegax = 0.009557
+      glIzmOmegay = 0.003515
+      glIzmXshift = 20.07
+      glIzmYshift = 0.0
+      glIzmDeltaE = 0.01984
+      glIzmCoupC = 0.0006127
+      call FMS_ESInit(num_particles, num_states, suppress_write=.true.)
+      call T1%create(numparticles=num_particles, numstates=num_states)
+      call T2%create(numparticles=num_particles, numstates=num_states)
+
+      mass = 0.0005485
+      pos = [-9.8126, 0.0000, 0.0000, 14.2616, 0.0000, 0.0000]
+      mom = [0.0938, 0.0000, 0.0000, 0.0035, 0.0000, 0.0000]
+      vel = mom / mass
+      call T1%set_pos(pos)
+      call T1%set_mom(mom)
+      call T1%set_vel(vel)
+      T1%StateID = 1
+      T1%Phase = 6.1910
+      T1%Particle(:)%mass = mass
+      T1%Particle(1)%width = 0.004775
+      T1%Particle(2)%width = 0.001675
+
+      pos = [-9.4015, 0.0000, 0.0000, 14.2493, 0.0000, 0.0000]
+      mom = [0.2116, 0.0000, 0.0000, 0.0022, 0.0000, 0.0000]
+      vel = mom / mass
+      call T2%set_pos(pos)
+      call T2%set_mom(mom)
+      call T2%set_vel(vel)
+      T2%StateID = 1
+      T2%Phase = 0.0320
+      T2%Particle(:)%mass = 0.0005485
+      T2%Particle(1)%width = 0.004775
+      T2%Particle(2)%width = 0.001675
+
+      SDot_analytical = overlap_S_dot(T1, T2)
+      ! calculates SDot numerically, (<chi_2(t)|chi_2(t+h)> - <chi_2(t)|chi_2(t-h)>)/2
+      ! with seven different step sizes h = 1.d-1, 1.d-2, ..., 1.d-7
+      SDot_numerical = get_numerical_time_derivative(T1, T2, 'S')
+      ! since the numerical derivative suffers from cancelations at small h,
+      ! we look for the smallest
+      min_err = minval(abs(SDot_analytical - SDot_numerical))
+      call check(error, min_err < atol + rtol * abs(SDot_analytical(1)), 'Analytical SDot ' &
+                 //'significantly from numerical one')
+      if (allocated(error)) return
+
+      call T1%destroy()
+      call T2%destroy()
+   end subroutine test_overlap_S_dot
+
+end module test_overlap

--- a/unit_tests/test_overlap.F90
+++ b/unit_tests/test_overlap.F90
@@ -24,19 +24,20 @@ contains
 
    end subroutine collect_overlap_suite
 
-   function get_numerical_time_derivative(T1, T2, integral_type) result(num_dt)
+   function get_numerical_time_derivative(T1, T2, integral_type, nr_steps, step_size) result(num_dt)
       use VerletModule, only: FMS_PropVV
       type(T_Trajectory), intent(in) :: T1, T2
       character, intent(in) :: integral_type
+      integer(kind=DefInt), intent(in) :: nr_steps
+      real(kind=DefReal), intent(in) :: step_size
+      real(kind=DefReal) :: step
       type(T_Trajectory) :: T1_tmp, T2_tmp
-      complex(kind=DefReal) :: num_dt(7)
-      real(kind=DefReal) :: step_size
+      complex(kind=DefReal) :: num_dt(nr_steps)
       complex(kind=DefReal) :: tmp_num_deriv, tmp
-      integer(kind=DefInt) :: i_direction, j_step, nr_steps, k, l
+      integer(kind=DefInt) :: j_step, k
 
-      step_size = 1.d-1
       num_dt = 0.d0
-      nr_steps = 7
+      step = step_size
       do j_step = 1, nr_steps
          tmp_num_deriv = 0.d0
 
@@ -45,7 +46,7 @@ contains
             T2_tmp = T2
 
             !call FMS_PropVV(T1_tmp, (-1.d0)**k * step_size)
-            call FMS_PropVV(T2_tmp, (-1.d0)**k * step_size)
+            call FMS_PropVV(T2_tmp, (-1.d0)**k * step)
 
             select case (integral_type)
             case ('S')
@@ -57,8 +58,8 @@ contains
             tmp_num_deriv = tmp_num_deriv + (-1)**k * tmp
          end do
 
-         num_dt = 0.5d0 * tmp_num_deriv / step_size
-         step_size = step_size * 1.d-1
+         num_dt = 0.5d0 * tmp_num_deriv / step
+         step = step * step_size
       end do
    end function get_numerical_time_derivative
 
@@ -72,7 +73,7 @@ contains
       integer(kind=DefInt) :: num_particles, num_states
       complex(kind=DefReal) :: SDot_analytical(7)
       complex(kind=DefReal) :: SDot_numerical(7)
-      real(kind=DefReal) :: pos(6), mom(6), vel(6), force(6)
+      real(kind=DefReal) :: pos(6), mom(6), vel(6)
       real(kind=DefReal) :: mass
       real(kind=DefReal) :: min_err
 
@@ -86,7 +87,7 @@ contains
       glIzmYshift = 0.0
       glIzmDeltaE = 0.01984
       glIzmCoupC = 0.0006127
-      fmiOut = open_fms_out_to_null()
+      fmiOut = open_dev_null()
       call FMS_ESInit(num_particles, num_states)
       call T1%create(numparticles=num_particles, numstates=num_states)
       call T2%create(numparticles=num_particles, numstates=num_states)
@@ -119,7 +120,7 @@ contains
       SDot_analytical = overlap_S_dot(T1, T2)
       ! calculates SDot numerically, (<chi_2(t)|chi_2(t+h)> - <chi_2(t)|chi_2(t-h)>)/2
       ! with seven different step sizes h = 1.d-1, 1.d-2, ..., 1.d-7
-      SDot_numerical = get_numerical_time_derivative(T1, T2, 'S')
+      SDot_numerical = get_numerical_time_derivative(T1, T2, 'S', 7, 1.d-1)
       ! since the numerical derivative suffers from catastrophic cancelations
       ! at small h, we look for the smallest error
       ! see, e.g., https://en.wikipedia.org/wiki/Numerical_differentiation#/media/File%3AAbsoluteErrorNumericalDifferentiationExample.png
@@ -132,11 +133,10 @@ contains
       call T2%destroy()
    end subroutine test_overlap_S_dot
 
-   function open_fms_out_to_null() result(output_unit)
+   function open_dev_null() result(output_unit)
       integer :: output_unit
-      character(len=256) :: filepath
 
-      open (newunit=output_unit, file='/dev/null', status='replace')
-   end function open_fms_out_to_null
+      open (newunit=output_unit, file='/dev/null', action='write')
+   end function open_dev_null
 
 end module test_overlap

--- a/unit_tests/test_overlap.F90
+++ b/unit_tests/test_overlap.F90
@@ -51,7 +51,8 @@ contains
             case ('S')
                tmp = overlap(T1_tmp, T2_tmp)
             case default
-               return
+               print*,'You really should not be seeing this error message!'
+               stop 1
             end select
             tmp_num_deriv = tmp_num_deriv + (-1)**k * tmp
          end do
@@ -118,8 +119,9 @@ contains
       ! calculates SDot numerically, (<chi_2(t)|chi_2(t+h)> - <chi_2(t)|chi_2(t-h)>)/2
       ! with seven different step sizes h = 1.d-1, 1.d-2, ..., 1.d-7
       SDot_numerical = get_numerical_time_derivative(T1, T2, 'S')
-      ! since the numerical derivative suffers from cancelations at small h,
-      ! we look for the smallest
+      ! since the numerical derivative suffers from catastrophic cancelations
+      ! at small h, we look for the smallest error
+      ! see, e.g., https://en.wikipedia.org/wiki/Numerical_differentiation#/media/File%3AAbsoluteErrorNumericalDifferentiationExample.png
       min_err = minval(abs(SDot_analytical - SDot_numerical))
       call check(error, min_err < atol + rtol * abs(SDot_analytical(1)), 'Analytical SDot ' &
                  //'significantly from numerical one')


### PR DESCRIPTION
This is a bit of a hacky unit test, as I set a lot of global variables that would otherwise be set in the initialization phase of the main function. That said, this unit test confirms that the `overlap_S_dot_trajectory` function is correctly implemented, thus settling the issue with the sign in the comments. However, one can easily see why there has to be minus sign in the following term

```
(-dot_product(T2%get_vel(), overlap_dx_trajectory(T1, T2, S_ij))
```

by noticing that $\nabla_\mathbf{R} \chi_i = -\nabla_{\mathbf{R}_i} \chi_i$. 