### PR TITLE
Fix Makefile dependency on openfms.f90

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ SUFFIXES=.f .c .F
 FMSLIB = src/libfms.a
 MAIN = src/openfms.o src/build_info.o
 
+$(MAIN): $(FMSLIB)
 # NOTE: It's important to use $(MAKE) for working parallel compilation!
 # https://stackoverflow.com/a/60706372/3682277
 $(FMSLIB): CONFIGFMS FORCE bin
@@ -73,7 +74,7 @@ bin:
 	mkdir bin
 
 # This is standalone OpenFMS, without external electronic structure
-bin/$(PROGBASE).zero: $(FMSLIB) $(MAKEFILE)
+bin/$(PROGBASE).zero: $(FMSLIB) $(MAIN) $(MAKEFILE)
 		@echo;echo "Linking $(PROGRAM) ..."
 		$(LD) $(MAIN) $(FMSLIB) -I$(MODULEDIR) -o $(TARGET) $(LIBS) $(LDFLAGS)
 		@rm -f bin/$(PROGBASE)
@@ -81,14 +82,14 @@ bin/$(PROGBASE).zero: $(FMSLIB) $(MAKEFILE)
 		@echo "done"
 
 # OpenFMS with TeraChem interface
-bin/$(PROGBASE).tc: $(FMSLIB) $(MAKEFILE)
+bin/$(PROGBASE).tc: $(FMSLIB) $(MAIN) $(MAKEFILE)
 		@rm -f bin/$(PROGBASE)
 		@echo;echo "Linking $(PROGRAM) ..."
 		$(LD) $(FFLAGS) $(MAIN) $(FMSLIB) -o $(TARGET) $(LIBS) $(LDFLAGS)
 		@ln -s $(PROGRAM) bin/$(PROGBASE)
 		@echo "done"
 
-bin/$(PROGBASE).quantics: $(FMSLIB) $(MAKEFILE)
+bin/$(PROGBASE).quantics: $(FMSLIB) $(MAIN) $(MAKEFILE)
 		@rm -f bin/$(PROGBASE)
 		@echo;echo "Linking $(PROGRAM) ..."
 		$(LD) $(MAIN) $(FMSLIB) -I$(MODULEDIR) -o $(TARGET) $(LIBS) $(LDFLAGS) -J$(QUANTICS_OBJ)/include -L$(QUANTICS_DIR)/bin/dyn_libs -lsrf -lusrf -lsqlite3 -Wl,-rpath=$(QUANTICS_DIR)/bin/dyn_libs

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,7 +87,7 @@ build_info.F90: FORCE
 	../generate_build_info.sh $@
 
 # Always recompile build_info.F90 to keep the git revision up to date.
-build_info.o: build_info.F90 $(OBJS) $(MOD_OBJS)
+build_info.o: build_info.F90 openfms.o $(OBJS) $(MOD_OBJS)
 	$(FC) -c $(FFLAGS) -I $(MODULEDIR) -DOPENFMS_BUILD_DATE="'$(BUILD_DATE)'" $<
 
 %.o : %.F


### PR DESCRIPTION
The binary would not be relinked if `openfms.f90` changed

This is a follow-up to #29 