### PR TITLE
Add copy_from subroutine for Particle class

### DIFF
--- a/src/modules/ParticleModule.f90
+++ b/src/modules/ParticleModule.f90
@@ -44,6 +44,7 @@ module ParticleModule
       procedure, public :: create => create_particle
       procedure, public :: destroy => destroy_particle
       procedure, public :: print_info => print_particle_info
+      procedure, public :: copy_from
       procedure :: get_position_component
       procedure :: get_position_vec
       procedure :: get_momentum_component
@@ -144,6 +145,12 @@ contains
       P1%Momentum2 = P2%Momentum2
    end subroutine assign_particle
 
+   subroutine copy_from(P1, P2)
+      class(T_Particle), intent(inout) :: P1
+      class(T_Particle), intent(in) :: P2
+
+      call assign_particle(P1, P2)
+   end subroutine copy_from
 !>
 !!    Memory deallocation to destroy a particle structure
 !!    \param Particle Particle to annihilate

--- a/src/modules/TrajectoryModule.f90
+++ b/src/modules/TrajectoryModule.f90
@@ -552,7 +552,7 @@ contains
       end if
 
       do IParticle = 1, T1%NumParticles
-         T1%Particle(IParticle) = T2%Particle(IParticle)
+         call T1%Particle(IParticle)%copy_from(T2%Particle(IParticle))
       end do
 
       T1%ElecStruc%PotEn = T2%ElecStruc%PotEn


### PR DESCRIPTION
As we discussed today @danielhollas here is the `copy_from` subroutine for the Particle class. I tried to find another occurrence of where the particle data is copied but couldn't find any except for in the obvious Trajectory assignment subroutine. 