### PR TITLE
Don't run unit tests with nvfortran

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,9 @@ jobs:
         toolchain:
           - {compiler: gcc, version: latest}
           - {compiler: intel, version: latest}
-          - {compiler: nvidia-hpc, version: '26.5'}
+          # Nvidia compiler results are flaky, probably due to
+          # https://forums.developer.nvidia.com/t/nvfortran-error-illegal-instruction-core-dumped/370976
+          # - {compiler: nvidia-hpc, version: '26.5'}
           - {compiler: aocc, version: '5.1.0'}
         include:
           - os: ubuntu-22.04
@@ -52,6 +54,7 @@ jobs:
 
     - name: Configure
       run: ./configure.sh
+
     - name: Build
       run: make -j
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,6 @@ jobs:
       run: make -j
 
     - name: Unit tests
-      # nvfortran sometimes fails with "Illegal instruction (core dumped)"
-      if: matrix.toolchain.compiler != 'nvidia-hpc'
       run: make unittest
 
     - name: End-to-end tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
       run: make -j
 
     - name: Unit tests
+      # nvfortran sometimes fails with "Illegal instruction (core dumped)"
+      if: matrix.toolchain.compiler != 'nvidia-hpc'
       run: make unittest
 
     - name: End-to-end tests


### PR DESCRIPTION
~~Unit tests with with nvfortran are flaky so let's disable them for now.~~

It's not just unit tests. I think this might be the culprit https://forums.developer.nvidia.com/t/nvfortran-error-illegal-instruction-core-dumped/370976